### PR TITLE
Add git ignore and fix gradle build to compile jar with the manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+*.class
+.DS_Store
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+!gradle-wrapper.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Editor settings
+.idea/
+.ideaDataSources/
+/*.iws
+/*.ipr
+/*.iml
+/*.iml
+
+# Compile location
+.gradle/*
+target/
+build/
+out/
+Yuuko.jar
+
+# Configuration files
+metrics_configuration.txt
+configuration.txt

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,26 @@
 plugins {
-    id 'java'
+    id 'application'
+}
+
+apply plugin: 'java'
+apply plugin: 'idea'
+
+group = 'com.yuuko.core'
+version = '12-01-2019_3'
+sourceCompatibility = 1.10
+mainClassName = 'com.yuuko.core.Yuuko'
+
+jar {
+    doFirst {
+        manifest {
+            if (!configurations.compile.isEmpty()) {
+                attributes(
+                        'Class-Path': configurations.compile.collect { it.toURI().toString() }.join(' '),
+                        'Main-Class': mainClassName
+                )
+            }
+        }
+    }
 }
 
 repositories {
@@ -22,7 +43,3 @@ dependencies {
     compile 'org.jsoup:jsoup:1.11.3'
     compile 'org.reflections:reflections:0.9.11'
 }
-
-group = 'com.yuuko.core'
-version = '12-01-2019_3'
-sourceCompatibility = '11'


### PR DESCRIPTION
This PR adds a `.gitignore` file which will ignore any compiled or built files, logs files, and configuration files, the RP also fixes Gradle so when compiling the application the main class is included in the manifest so the application can be run after compiling.